### PR TITLE
Removed unwanted semicolon

### DIFF
--- a/template/.openshift/action_hooks/deploy
+++ b/template/.openshift/action_hooks/deploy
@@ -4,4 +4,4 @@ echo "Deploying..."
 
 # Composer and automatically install dependencies on deploy.
 #
-; cd $OPENSHIFT_REPO_DIR; composer install
+cd $OPENSHIFT_REPO_DIR; composer install


### PR DESCRIPTION
This semicolon causes a syntax error and deploy fails. Removed it.